### PR TITLE
Change reader to clojure.edn reader in anticipation of 1.5.0

### DIFF
--- a/examples/awe/project.clj
+++ b/examples/awe/project.clj
@@ -1,7 +1,7 @@
 (defproject awesomeness "0.0.1"
   :description "true power awesomeness"
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.5.0-RC15"]
                  [ring "1.0.2"]
                  [compojure "1.0.1"]
-                 [fogus/ring-edn "0.1.0"]]
+                 [fogus/ring-edn "0.1.0-SNAPSHOT"]]
   :main awesome-app)

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,5 @@
-(defproject fogus/ring-edn "0.1.0"
+(defproject fogus/ring-edn "0.1.0-SNAPSHOT"
   :description "A Ring middleware that augments :params by parsing a request body as Extensible Data Notation (EDN)."
-  :dependencies [[org.clojure/clojure "1.4.0"]]
+  :dependencies [[org.clojure/clojure "1.5.0-RC15"]]
   :plugins [[lein-swank "1.4.4"]
             [lein-marginalia "0.8.0-SNAPSHOT"]])
-

--- a/src/ring/middleware/edn.clj
+++ b/src/ring/middleware/edn.clj
@@ -1,4 +1,5 @@
-(ns ring.middleware.edn)
+(ns ring.middleware.edn
+  (:require clojure.edn))
 
 (defn- edn-request?
   [req]
@@ -11,16 +12,16 @@
 (extend-type String
   EdnRead
   (-read-edn [s]
-    (read-string s)))
+    (clojure.edn/read-string s)))
 
 (extend-type java.io.InputStream
   EdnRead
   (-read-edn [is]
-    (read (java.io.PushbackReader.
-           (java.io.InputStreamReader.
-             is "UTF-8"))
-          false
-          nil)))
+    (clojure.edn/read
+     {:eof nil}
+     (java.io.PushbackReader.
+                       (java.io.InputStreamReader.
+                        is "UTF-8")))))
 
 (defn wrap-edn-params
   [handler]
@@ -32,4 +33,3 @@
                    :params (merge (:params req) edn-params))]
         (handler req*))
       (handler req))))
-


### PR DESCRIPTION
I have changed the reader to the clojure.edn reader and the Clojure dependency to 1.5.0-RC15. The version has been changed to SNAPSHOT.
