### PR TITLE
Added opts as defined in clojure.edn/read-string

### DIFF
--- a/src/ring/middleware/edn.clj
+++ b/src/ring/middleware/edn.clj
@@ -7,29 +7,41 @@
     (not (empty? (re-find #"^application/(vnd.+)?edn" type)))))
 
 (defprotocol EdnRead
-  (-read-edn [this]))
+  "Specifies that the object can be read and transformed to edn"
+  (-read-edn [this] [this opts]
+    "Transforms the serialized object into edn.
+     May take an opts map to pass to clojure.edn/read-string"))
 
 (extend-type String
   EdnRead
-  (-read-edn [s]
-    (clojure.edn/read-string s)))
+  (-read-edn
+    ([s] (-read-edn s {}))
+    ([s opts]
+     (clojure.edn/read-string opts s))))
 
 (extend-type java.io.InputStream
   EdnRead
-  (-read-edn [is]
-    (clojure.edn/read
-     {:eof nil}
-     (java.io.PushbackReader.
-                       (java.io.InputStreamReader.
-                        is "UTF-8")))))
+  (-read-edn
+    ([is] (-read-edn is {}))
+    ([is opts]
+     (clojure.edn/read
+       (merge {:eof nil} opts)
+       (java.io.PushbackReader.
+         (java.io.InputStreamReader. is "UTF-8"))))))
 
 (defn wrap-edn-params
-  [handler]
-  (fn [req]
-    (if-let [body (and (edn-request? req) (:body req))]
-      (let [edn-params (binding [*read-eval* false] (-read-edn body))
-            req* (assoc req
-                   :edn-params edn-params
-                   :params (merge (:params req) edn-params))]
-        (handler req*))
-      (handler req))))
+  "If the request has the edn content-type, it will attempt to read
+  the body as edn and then assoc it to the request under :edn-params
+  and merged to :params.
+
+  It may take an opts map to pass to clojure.edn/read-string"
+  ([handler] (wrap-edn-params handler {}))
+  ([handler opts]
+   (fn [req]
+     (if-let [body (and (edn-request? req) (:body req))]
+       (let [edn-params (binding [*read-eval* false] (-read-edn body opts))
+             req* (assoc req
+                    :edn-params edn-params
+                    :params (merge (:params req) edn-params))]
+         (handler req*))
+       (handler req)))))


### PR DESCRIPTION
This will allow users to define readers for their own custom types.

Notes:

* The current implementation might have one caveat, when merging the opts in `(merge {:eof nil} opts)` for `java.io.InputStream` the user might override `:eof` with some new character. I don't know if this level of customization is desirable.
* The docs refer to `clojure.edn/read-string` to describe the opts map. Though inconvenient for the user, it ensures it will be kept in sync with `read-string`'s implementation.
* The new option is not covered in the README. I don't know what to assume the user knows about custom types and tagged literals. If a mini tutorial is desirable, I'll make one.