### PR TITLE
Added example to use custom types with wrap-edn-params to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,6 +66,49 @@ And finally, create another file in `src` named `awesome_app.clj` with the follo
   (run-jetty #'awe/app {:port 8080}))
 ```
 
+### Using custom types
+
+EDN offers extensible types through
+[tagged literals](https://github.com/edn-format/edn#tagged-elements)
+and `ring-edn` can read those types from the incoming requests.
+As an example, let's add `uri` to EDN. In our Clojure program
+it will be represented by `java.net.URI` but in other platforms it
+might be represented differently, i.e `goog.Uri` in ClojureScript. To
+use a new type, we need to define a reader (takes a string and returns
+our representation) and a printer (takes our representation and writes
+it as a string). The printer determines the tagged literal and it is
+implemented as a multimethod of `clojure.core/print-method`. We might
+be tempted to use `#uri` for the tagged literal but it needs to be
+namespaced in case an application needs to deal with multiple `uri`
+representations. Therefore we will use `#my-app/uri`:
+
+```clj
+(ns my-app.uri
+  (:import (java.net URI)))
+
+(defn read-uri [s]
+  (URI. s))
+
+(defmethod print-method java.net.URI [this w]
+  (.write w "#my-app/uri \"")
+  (.write w (.toString this))
+  (.write w "\""))
+```
+
+Now we indicate `wrap-edn-params` that whenever it finds `#my-app/uri`
+it should read the expression that follows with `read-uri`:
+
+```
+(def app
+  (-> handler
+      (wrap-edn-params {:readers {'my-app/uri #'my-app.uri/read-uri}})))
+```
+
+Other options besides `:readers` can be passed to `wrap-edn-params`
+which are forwarded to `clojure.edn/read-string` as defined
+[here](https://clojure.github.io/clojure/clojure.edn-api.html).
+
+
 ### Testing
 
 Run this app in your console with `lein run` and test with `curl` using the following:
@@ -73,23 +116,23 @@ Run this app in your console with `lein run` and test with `curl` using the foll
 ```sh
 $ curl -X GET http://localhost:8080/
 
-#=> {:hello :cleveland}                               
+#=> {:hello :cleveland}
 
 $ curl -X PUT -H "Content-Type: application/edn" \ 
   -d '{:name :barnabas}' \
   http://localhost:8080/ 
 
-#=> {:hello :barnabas}%  
+#=> {:hello :barnabas}%
 ```
 
 You can also run the test suite with `lein test`.
 
 ## Acknowledgment(s)
 
-Thanks to [Mark McGranaghan](http://markmcgranaghan.com/) for his work on Ring and [ring-json-params](https://github.com/mmcgrana/ring-json-params) on which this project was based.  
+Thanks to [Mark McGranaghan](http://markmcgranaghan.com/) for his work on Ring and [ring-json-params](https://github.com/mmcgrana/ring-json-params) on which this project was based.
 
 ## License
 
-Copyright (C) 2012,2013 Fogus
+Copyright (C) 2012-2015 Fogus
 
 Distributed under the Eclipse Public License, the same as Clojure.


### PR DESCRIPTION
Besides adding the example I removed some trailing white-space and updated the Copyright to 2015.