### PR TITLE
:content-type is deprecated

### DIFF
--- a/src/ring/middleware/edn.clj
+++ b/src/ring/middleware/edn.clj
@@ -3,7 +3,7 @@
 
 (defn- edn-request?
   [req]
-  (if-let [^String type (:content-type req)]
+  (if-let [^String type (get-in req [:headers "content-type"] "")]
     (not (empty? (re-find #"^application/(vnd.+)?edn" type)))))
 
 (defprotocol EdnRead


### PR DESCRIPTION
In `[ring/ring-core "1.4.0-RC1"]` this key is no longer in the request map.
